### PR TITLE
Solves Error:1235 in MySQL.

### DIFF
--- a/ultimatelogs/lua/ultimatelogs/server/sv_ultimatelogs.lua
+++ b/ultimatelogs/lua/ultimatelogs/server/sv_ultimatelogs.lua
@@ -174,8 +174,8 @@ ULogs.CheckLimit = function( CallBack )
 			
 			if lines > ULogs.config.Limit then
 				
-				ULogs.Query( "DELETE FROM " .. ULogs.config.TableName .. " WHERE id IN( SELECT id FROM " .. ULogs.config.TableName .. " ORDER BY id ASC LIMIT 1)", function()
-					
+				ULogs.Query( "DELETE FROM " .. ULogs.config.TableName .. " WHERE id IN(SELECT id FROM (SELECT id FROM " .. ULogs.config.TableName .. " ORDER BY `id` ASC LIMIT 1) x)", function()
+			
 					CallBack()
 					return
 					


### PR DESCRIPTION
This solves following error below.

addons/ulogs-master/lua/ultimatelogs/server/sv_ultimatelogs.lua:48: [ULogs] Query error : This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery' on query : 'DELETE FROM ulogs WHERE id IN ( SELECT id FROM ulogs ORDER BY id ASC LIMIT 1)'